### PR TITLE
print errors along with lint codeGen use ExceptT

### DIFF
--- a/grin/grin/sum_opt_lint_errors.grin
+++ b/grin/grin/sum_opt_lint_errors.grin
@@ -1,0 +1,12 @@
+grinMain =
+  n13 <- sum 0 1 100000
+  _prim_int_print n13
+
+sum n29 n30 n31 =
+  b2 <- _prim_int_gt n30 n31_
+  if b2 then
+    pure n29
+  else
+    n18 <- _prim_int_add n30 1
+    n28 <- _prim_int_add n29_ n30_
+    sum n28 n18 n31

--- a/grin/src/Eval.hs
+++ b/grin/src/Eval.hs
@@ -28,8 +28,8 @@ eval' reducer fname = do
         PureReducer -> Reducer.Pure.reduceFun program "grinMain"
         IOReducer   -> Reducer.IO.reduceFun program "grinMain"
         LLVMReducer -> LLVM.eagerJit (LLVM.codeGen typeEnv program) "grinMain" where
-          typeEnv     = either error id $ typeEnvFromHPTResult hptResult
-          hptResult   = HPT.toHPTResult hptProgram $ HPT.evalHPT hptProgram
+          typeEnv     = either error id $ typeEnvFromHPTResult =<< hptResult
+          hptResult   = HPT.toHPTResult <$> hptProgram <*> (HPT.evalHPT <$> hptProgram)
           hptProgram  = HPT.codeGen program
 
 evalProgram :: Reducer -> Program -> IO Val

--- a/grin/src/Pipeline.hs
+++ b/grin/src/Pipeline.hs
@@ -260,7 +260,10 @@ pipelineStep p = do
 compileHPT :: PipelineM ()
 compileHPT = do
   grin <- use psExp
-  let hptProgram = HPT.codeGen grin
+  hptProgram <-
+    case HPT.codeGen grin of
+      Left e -> psErrors %= (e:) >> pure HPT.emptyHPTProgram
+      Right a -> pure a
   psHPTProgram .= Just hptProgram
   let nonlinearSet  = nonlinearVariables grin
       countMap      = countVariableUse grin
@@ -404,7 +407,7 @@ lintGrin mPhaseName = do
   unless (Prelude.null errors) $ void $ do
     failOnLintError <- view poFailOnLint
     when failOnLintError $ void $ do
-      --liftIO . print $ prettyLintExp lintExp -- TODO: print code with errors
+      liftIO . print $ prettyLintExp lintExp
       pipelineStep $ HPT PrintHPTResult
       pipelineStep $ PrintGrin ondullblack
     case mPhaseName of

--- a/grin/src/PrettyLint.hs
+++ b/grin/src/PrettyLint.hs
@@ -20,7 +20,13 @@ keywordR = red . text
 
 prettyLintExp :: (Cofree ExpF Int, Map Int [Error]) -> Doc
 prettyLintExp (exp, errorMap) = cata folder exp where
-  folder (expId CCTC.:< e) = {-fill 8 (int expId) <> -}prettyExpAlgebra e -- <> indent 2 (red $ vsep $ map text $ Map.findWithDefault [] expId errorMap) <> linebreak
+  folder (expId CCTC.:< e) = addError expId (prettyExpAlgebra e)
+
+  addError expId d =
+    maybe
+      d
+      ((d <>) . red . (string " <- "<>) . align . vsep . map string )
+      (Map.lookup expId errorMap)
 
   prettyExpAlgebra = \case
       ProgramF defs       -> vcat (map pretty defs)

--- a/grin/src/TypeCheck.hs
+++ b/grin/src/TypeCheck.hs
@@ -82,7 +82,7 @@ typeEnvFromHPTResult hptResult = typeEnv where
     mapM convertFunction (_function hptResult)
 
 inferTypeEnv :: Exp -> TypeEnv.TypeEnv
-inferTypeEnv exp = either error id $ typeEnvFromHPTResult result where
+inferTypeEnv exp = either error id $ typeEnvFromHPTResult =<< result where
   hptProgram = HPT.codeGen exp
-  hptResult = HPT.evalHPT hptProgram
-  result = HPT.toHPTResult hptProgram hptResult
+  hptResult = HPT.evalHPT <$> hptProgram
+  result = HPT.toHPTResult <$>  hptProgram <*> hptResult


### PR DESCRIPTION
Change `codeGen` to use `ExceptT` instead of using `error` and print the
linting errors along with the lint output.

![grin-pretty-ling](https://user-images.githubusercontent.com/1398648/41192773-4cba81b4-6c03-11e8-85ed-5f7523b014f9.png)